### PR TITLE
fix issue 121 - paidMediaPurchased payload incorrect name from json f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enh #119: Use fully qualified function calls to improve performance.
 - Enh #119: Use more specific psalm annotations.
+- Bug #121: Rename `PaidMediaPurchased` property `paidMediaPayload` to `payload`. 
 
 ## 0.4.3 September 06, 2024
 

--- a/src/Type/Payment/PaidMediaPurchased.php
+++ b/src/Type/Payment/PaidMediaPurchased.php
@@ -13,6 +13,6 @@ final readonly class PaidMediaPurchased
 {
     public function __construct(
         public User $from,
-        public string $paidMediaPayload,
+        public string $payload,
     ) {}
 }

--- a/src/Type/Payment/PaidMediaPurchased.php
+++ b/src/Type/Payment/PaidMediaPurchased.php
@@ -13,6 +13,8 @@ final readonly class PaidMediaPurchased
 {
     public function __construct(
         public User $from,
+        // As of 26.10.2024, Telegram Bot API documentation contains incorrect name "paid_media_payload".
+        // Real API use "payload" name.
         public string $payload,
     ) {}
 }

--- a/tests/Type/Payment/PaidMediaPurchasedTest.php
+++ b/tests/Type/Payment/PaidMediaPurchasedTest.php
@@ -17,7 +17,7 @@ final class PaidMediaPurchasedTest extends TestCase
         $object = new PaidMediaPurchased($user, 'payload');
 
         $this->assertSame($user, $object->from);
-        $this->assertSame('payload', $object->paidMediaPayload);
+        $this->assertSame('payload', $object->payload);
     }
 
     public function testFromTelegramResult(): void
@@ -29,7 +29,7 @@ final class PaidMediaPurchasedTest extends TestCase
                     'is_bot' => false,
                     'first_name' => 'Vjik',
                 ],
-                'paid_media_payload' => 'test',
+                'payload' => 'test',
             ],
             null,
             PaidMediaPurchased::class,
@@ -38,6 +38,6 @@ final class PaidMediaPurchasedTest extends TestCase
         $this->assertInstanceOf(User::class, $object->from);
         $this->assertSame(1, $object->from->id);
 
-        $this->assertSame('test', $object->paidMediaPayload);
+        $this->assertSame('test', $object->payload);
     }
 }

--- a/tests/Type/Update/UpdateTest.php
+++ b/tests/Type/Update/UpdateTest.php
@@ -208,7 +208,7 @@ final class UpdateTest extends TestCase
                     'is_bot' => false,
                     'first_name' => 'Vjik',
                 ],
-                'paid_media_payload' => 'test',
+                'payload' => 'test',
             ],
             'poll' => [
                 'id' => 'poll1',


### PR DESCRIPTION
should be "payload" not "paid_media_payload" in PaidMediaPurchased update.