### PR TITLE
Use php-64bit constraint in composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.9.1 under development
 
-- New #155: Add `NativeTransport` that used native `file_get_contents()` and `file_put_contents()` functions.  
+- New #155: Add `NativeTransport` that used native `file_get_contents()` and `file_put_contents()` functions.
+- Chg #160: Change PHP constraint in `composer.json` from `php` to `php-64bit`.
 
 ## 0.9.0 April 12, 2025
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package provides a simple and convenient way to interact with the Telegram B
 
 ## Requirements
 
-- PHP 8.2 or higher.
+- PHP (64-bit) 8.2 or higher.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^8.2",
+        "php-64bit": "^8.2",
         "php-http/multipart-stream-builder": "^1.4.2",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.1",


### PR DESCRIPTION
This library uses `int` type for Chat::$id, for instance. According to Telegram docs chat.id might have up to 52 significant bits. This means that this library can be safely used on 64-bit platforms only.

See https://getcomposer.org/doc/articles/composer-platform-dependencies.md#different-types-of-platform-packages for more information.